### PR TITLE
added robots.txt and metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,6 +27,14 @@ export const metadata: Metadata = {
   },
 };
 
+/**
+ * Root layout component that applies global fonts, page-level HTML attributes, and renders app content.
+ *
+ * Renders an `<html lang="en">` element with font-related CSS variables and utility classes, and a `<body>` that wraps the provided children.
+ *
+ * @param children - The React nodes to render inside the application's body
+ * @returns The root HTML structure containing the rendered children
+ */
 export default function RootLayout({
   children,
 }: Readonly<{

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -16,6 +16,15 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "創作展　貸出備品管理サイト",
   description: "創作展中の備品貸出管理サイト",
+  robots: {
+    index: false,
+    follow: false,
+    googleBot: {
+      index: false,
+      follow: false,
+      noimageindex: true,
+    },
+  },
 };
 
 export default function RootLayout({

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
このサイトは外部に公開されるものではないと思ったため、GoogleやMicrosoftなどのBotのクロールを拒否するrobots.txtなどを追加しました
何か認識に間違いがあったら教えてください。リンクなどからは引き続きアクセスできるはずです。

I thought this website should not be publicly accessible so I added robots.txt to prevent crawling such as googlebot and Microsoft bot

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Disabled search engine indexing and link following across the site to prevent pages from appearing in search results.
  * Added site-wide robots directives to block all web crawlers from accessing any pages, including preventing image indexing by Google.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->