### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -12,6 +12,9 @@ on:
   # Allow manual trigger from Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Type Check


### PR DESCRIPTION
Potential fix for [https://github.com/KSS-IT-Committee/2026-sousakuten-equipment-management/security/code-scanning/1](https://github.com/KSS-IT-Committee/2026-sousakuten-equipment-management/security/code-scanning/1)

Add an explicit top-level `permissions` block in `.github/workflows/build-check.yml` so all jobs inherit least-privilege token access unless overridden.  
Best fix (minimal and non-functional): set:

- `permissions:`
  - `contents: read`

This is sufficient for checkout and typical read-only CI tasks in this workflow and does not alter build/lint behavior.  
Change location: near the top of the workflow, after triggers (`on:` block) and before `jobs:`.

No imports, methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
