### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,5 +1,8 @@
 name: Build Check
 
+permissions:
+  contents: read
+
 on:
   # Trigger on pull requests to main branch
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/KSS-IT-Committee/2026-sousakuten-equipment-management/security/code-scanning/2](https://github.com/KSS-IT-Committee/2026-sousakuten-equipment-management/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so it applies to all jobs (`build`, `lint`, and `checks-summary`) unless overridden.  
For this workflow, `contents: read` is sufficient as a minimal and safe default because the jobs only check out code, install dependencies, run type checks/lint/build, and evaluate job results—none require writing to repository resources.

**Where to change:**
- File: `.github/workflows/build-check.yml`
- Insert immediately after the workflow `name` (before `on:`), so permissions are globally applied.

No imports, methods, or dependencies are needed—this is YAML configuration only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
