### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,5 +1,8 @@
 name: Build Check
 
+permissions:
+  contents: read
+
 on:
   # Trigger on pull requests to main branch
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/KSS-IT-Committee/2026-sousakuten-equipment-management/security/code-scanning/3](https://github.com/KSS-IT-Committee/2026-sousakuten-equipment-management/security/code-scanning/3)

Add an explicit top-level `permissions` block to `.github/workflows/build-check.yml` so all jobs inherit least-privilege token scopes.

Best fix (without changing functionality):  
- Insert at workflow root (after `name` and before `on`) :
  - `permissions:`
  - `contents: read`

Why this is best:
- `actions/checkout` needs `contents: read`.
- No job in this file requires write permissions.
- Root-level permissions avoid repeating config in each job and keep behavior consistent.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
