### PR TITLE
copy drizzle.config.ts and drizzle/ into runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ COPY --from=builder --chown=nextjs:nodejs /app/package.json ./package.json
 COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
 COPY --from=builder --chown=nextjs:nodejs /app/next.config* ./
 
+COPY --from=builder --chown=nextjs:nodejs /app/drizzle.config.ts ./
+COPY --from=builder --chown=nextjs:nodejs /app/drizzle ./drizzle
+
 USER nextjs
 EXPOSE 3000
 


### PR DESCRIPTION
Required for the migrate-on-start hook (drizzle-kit migrate --config=drizzle.config.ts). Image currently exits at startup with 'file does not exist'. Aligns with sousakuten-info Dockerfile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
- Updated Docker build configuration to include database and ORM configuration files in the production runtime environment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KSS-IT-Committee/2026-sousakuten-equipment-management/pull/33)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->