### PR TITLE
Revert "Potential fix for code scanning alert no. 1: Workflow does not contain permissions"

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -15,9 +15,6 @@ on:
   # Allow manual trigger from Actions tab
   workflow_dispatch:
 
-permissions:
-  contents: read
-
 jobs:
   build:
     name: Build and Type Check


### PR DESCRIPTION
Reverts KSS-IT-Committee/2026-sousakuten-equipment-management#26

.github/workflows/build-check.ymlにpermissionsが2度書かれていてSyntaxErrorで落ちてしまいます。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build workflow to support manual trigger from GitHub Actions interface.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/KSS-IT-Committee/2026-sousakuten-equipment-management/pull/39)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->