### PR TITLE
Enforce Sousakuten-only mutations + class-scoped deduction views

### DIFF
--- a/app/add-equipment/page.tsx
+++ b/app/add-equipment/page.tsx
@@ -5,7 +5,7 @@ import { AuthGuard } from "@/components/AuthGuard";
 
 export default function AddEquipmentPage() {
   return (
-    <AuthGuard>
+    <AuthGuard role="Sousakuten">
       <AddEquipmentContent />
     </AuthGuard>
   );

--- a/app/equipment/edit/page.tsx
+++ b/app/equipment/edit/page.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export default async function EditEquipmentPage({ searchParams }: Props) {
   return (
-    <AuthGuard>
+    <AuthGuard role="Sousakuten">
       <EditEquipmentContent searchParams={searchParams} />
     </AuthGuard>
   );

--- a/app/equipment/page.tsx
+++ b/app/equipment/page.tsx
@@ -32,7 +32,7 @@ export default async function Equipment({ searchParams }: Props) {
 
   return (
     <div className={styles.cell}>
-      <Internal>
+      <Internal role="Sousakuten">
         <div className={styles.actionGroup}>
           <Link href={`/equipment/edit?id=${id}`} className={styles.editButton}>
             編集

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,7 +1,11 @@
+import { forbidden } from "next/navigation";
+
 import { AuthGuard } from "@/components/AuthGuard";
 import BackButton from "@/components/BackButton";
 import DeleteDeductionButton from "@/components/DeleteDeductionButton";
+import { Internal } from "@/components/Internal";
 import { getDeductionsById } from "@/db/queries/deductions";
+import { getViewer } from "@/lib/authorize";
 
 import styles from "./base.module.css";
 
@@ -31,6 +35,13 @@ async function DeductionDetail({ searchParams }: Props) {
     return <p>エラー: 無効なID</p>;
   }
 
+  // A non-admin may only see their own class's deduction — don't reveal another
+  // class's record via /history?id=N.
+  const viewer = await getViewer();
+  if (!viewer?.isAdmin && deduction.className !== viewer?.className) {
+    forbidden();
+  }
+
   return (
     <>
       <div className={styles.window}>
@@ -47,9 +58,11 @@ async function DeductionDetail({ searchParams }: Props) {
         </h2>
         <BackButton />
       </div>
-      <div className={styles.buttonRow}>
-        <DeleteDeductionButton deductionId={deduction.id} />
-      </div>
+      <Internal role="Sousakuten">
+        <div className={styles.buttonRow}>
+          <DeleteDeductionButton deductionId={deduction.id} />
+        </div>
+      </Internal>
     </>
   );
 }

--- a/components/AddEquipmentForm/action.ts
+++ b/components/AddEquipmentForm/action.ts
@@ -12,9 +12,11 @@ import {
   updateEquipment,
 } from "@/db/queries/equipments";
 import { Borrowings, Equipments } from "@/db/schema";
+import { isAdmin, requireAdmin } from "@/lib/authorize";
 import { db } from "@/lib/db";
 
 export async function createEquipmentAction(formData: FormData) {
+  await requireAdmin();
   const name = String(formData.get("name") ?? "").trim();
   const quantity = Number(formData.get("quantity"));
   // picture is now expected to be an image path string
@@ -42,6 +44,7 @@ export async function createEquipmentAction(formData: FormData) {
 }
 
 export async function updateEquipmentAction(formData: FormData) {
+  await requireAdmin();
   const equipmentId = Number(formData.get("equipmentId"));
   const name = String(formData.get("name") ?? "").trim();
   const quantity = Number(formData.get("quantity"));
@@ -87,6 +90,9 @@ export async function updateEquipmentAction(formData: FormData) {
 export async function deleteEquipmentAction(
   equipmentId: number,
 ): Promise<{ success: boolean; error?: string }> {
+  if (!(await isAdmin())) {
+    return { success: false, error: "この操作には創作展委員の権限が必要です" };
+  }
   if (!Number.isInteger(equipmentId) || equipmentId <= 0) {
     return { success: false, error: "備品IDが不正です" };
   }

--- a/components/BorrowingEquipList/index.tsx
+++ b/components/BorrowingEquipList/index.tsx
@@ -1,3 +1,4 @@
+import { Internal } from "@/components/Internal";
 import { ReturnButton } from "@/components/ReturnButton";
 import { getActiveBorrowingsByEquipmentId } from "@/db/queries/borrowings";
 import { getClassLabel } from "@/lib/class-number";
@@ -28,9 +29,11 @@ export async function BorrowingEquipList({ id }: { id: number }) {
               </span>
             </div>
 
-            <div className={styles.actionGroup}>
-              <ReturnButton borrowingId={borrowing.id} />
-            </div>
+            <Internal role="Sousakuten">
+              <div className={styles.actionGroup}>
+                <ReturnButton borrowingId={borrowing.id} />
+              </div>
+            </Internal>
           </div>
         ))
       )}

--- a/components/DeductionUI/index.tsx
+++ b/components/DeductionUI/index.tsx
@@ -3,6 +3,7 @@ import { DeductionSumsList } from "@/components/DeductionLists";
 import AddDeductionUI from "@/components/DeductionPopup";
 import SelectButtons from "@/components/UiButtons";
 import { CLASSES, type ClassName } from "@/db/schema";
+import { getViewer } from "@/lib/authorize";
 
 export type DeductionSortKey =
   | "className"
@@ -43,6 +44,25 @@ export async function DeductionUI({ searchParams }: Props) {
   )
     ? (resolvedSearchParams?.sortOrder as DeductionSortOrder)
     : "desc";
+
+  // Non-admins are scoped to their own class: no add control, no class filter,
+  // no all-class ranking, and the `class` query param is ignored. The data
+  // query is pinned to their class so `/deductions?class=5A` can't reveal it.
+  const viewer = await getViewer();
+  if (!viewer?.isAdmin) {
+    const ownClass = viewer?.className ?? null;
+    if (ownClass === null || !CLASSES.includes(ownClass as ClassName)) {
+      return <p className="text-center mt-8">表示できる減点はありません。</p>;
+    }
+    return (
+      <DeductionCellsByClasses
+        classes={[ownClass as ClassName]}
+        sortBy={sortBy}
+        sortOrder={sortOrder}
+      />
+    );
+  }
+
   const classParams = resolvedSearchParams?.class;
   const rawSelectedClasses = Array.isArray(classParams)
     ? classParams

--- a/components/Navbar/NavMenuLinks.tsx
+++ b/components/Navbar/NavMenuLinks.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 
+import { Internal } from "@/components/Internal";
+
 import styles from "./Navbar.module.css";
 
 /**
@@ -7,6 +9,9 @@ import styles from "./Navbar.module.css";
  * on the server so it can read the shared session; the layout wraps it in
  * <Internal> so it only renders for logged-in school accounts. Menu open/close
  * lives in the client Navbar, which receives this as a slot.
+ *
+ * Equipment management is committee-only, so the 備品追加 link is further gated
+ * to the Sousakuten role; everyone internal still sees ホーム and 減点管理.
  */
 export function NavMenuLinks() {
   return (
@@ -14,9 +19,11 @@ export function NavMenuLinks() {
       <Link href="/" className={styles.homeLink}>
         ホーム
       </Link>
-      <Link href="/add-equipment" className={styles.addEquipmentLink}>
-        備品追加
-      </Link>
+      <Internal role="Sousakuten">
+        <Link href="/add-equipment" className={styles.addEquipmentLink}>
+          備品追加
+        </Link>
+      </Internal>
       <Link href="/deductions" className={styles.borrowingsLink}>
         減点管理
       </Link>

--- a/lib/action.ts
+++ b/lib/action.ts
@@ -5,6 +5,7 @@ import { revalidatePath } from "next/cache";
 
 import { createDeduction, deleteDeductionById } from "@/db/queries/deductions";
 import { Borrowings, ClassName, Equipments } from "@/db/schema";
+import { requireAdmin } from "@/lib/authorize";
 import { CLASS_CODES, ClassCode } from "@/lib/class-number";
 import { db } from "@/lib/db";
 
@@ -12,6 +13,7 @@ export const returnBorrowingAction = async (
   borrowingId: number,
   returnedAt: Date,
 ) => {
+  await requireAdmin();
   await db.transaction(async (tx) => {
     const [existing] = await tx
       .select()
@@ -38,6 +40,7 @@ export const borrowEquipmentAction = async (
   equipmentId: number,
   classCode: ClassName,
 ) => {
+  await requireAdmin();
   if (!Number.isInteger(equipmentId) || equipmentId <= 0) {
     throw new Error("備品IDが不正です");
   }
@@ -86,6 +89,7 @@ export const createDeductionAction = async (data: {
   content: string;
   points: number;
 }) => {
+  await requireAdmin();
   if (!CLASS_CODES.includes(data.className as ClassCode)) {
     throw new Error("クラス名が不正です");
   }
@@ -107,6 +111,7 @@ export const createDeductionAction = async (data: {
 };
 
 export const deleteDeductionAction = async (id: number) => {
+  await requireAdmin();
   await deleteDeductionById(id);
   revalidatePath("/deductions");
   revalidatePath("/history");

--- a/lib/authorize.ts
+++ b/lib/authorize.ts
@@ -1,0 +1,48 @@
+import "server-only";
+
+import { hasAccess } from "@/lib/access";
+import { getCurrentUser } from "@/lib/session";
+import { classOf } from "@/lib/user-category";
+
+// The committee role allowed to *manage* this app: add/edit/delete equipment,
+// borrow/return, and add/delete deductions. Reading (the equipment catalog, a
+// class's own deductions) stays open to any logged-in school account.
+const ADMIN_ROLE = "Sousakuten";
+
+export async function isAdmin(): Promise<boolean> {
+  const user = await getCurrentUser();
+  if (!user) return false;
+  return hasAccess(user.username, ADMIN_ROLE, undefined);
+}
+
+/**
+ * Assert the caller holds the committee role; throws otherwise. Call this at the
+ * top of every mutating server action — AuthGuard / Internal only gate
+ * rendering, so an action stays directly invocable by anyone without it.
+ */
+export async function requireAdmin(): Promise<void> {
+  if (!(await isAdmin())) {
+    throw new Error("この操作には創作展委員の権限が必要です");
+  }
+}
+
+export type Viewer = {
+  username: string;
+  isAdmin: boolean;
+  /** The viewer's own class (e.g. "3B"), or null for staff/committee accounts. */
+  className: string | null;
+};
+
+/**
+ * The current viewer with their admin flag and own class, or null if not logged
+ * in. Drives read-scoping: admins see every class, everyone else only their own.
+ */
+export async function getViewer(): Promise<Viewer | null> {
+  const user = await getCurrentUser();
+  if (!user) return null;
+  return {
+    username: user.username,
+    isAdmin: await hasAccess(user.username, ADMIN_ROLE, undefined),
+    className: classOf(user.username),
+  };
+}


### PR DESCRIPTION
## Problem

`AuthGuard` / `Internal` only gate **rendering**. The mutating server actions (`createEquipmentAction`, `updateEquipmentAction`, `deleteEquipmentAction`, `borrowEquipmentAction`, `returnBorrowingAction`, `createDeductionAction`, `deleteDeductionAction`) had **no auth checks**, so anyone could invoke them directly — and the deductions data fetch ignored who was asking, so `/deductions?class=5A` (or `/history?id=N`) exposed any class. This adds enforcement at the **action + query layer**, with the guards as the UX layer on top.

## Access model

- **Mutations → Sousakuten only.** Add/edit/delete equipment, borrow, return, add/delete deduction.
- **Reads → any logged-in school account**, *except* deductions are scoped to the viewer's own class (admins see all).

## Changes

- **`lib/authorize.ts`** (new): `requireAdmin()` for actions, `isAdmin()`, and `getViewer()` (`{ username, isAdmin, className }`) for read-scoping. Built on `hasAccess`.
- **Server actions** all call `requireAdmin()` first (delete-equipment returns its `{success,error}` shape).
- **Page / UI guards:** `add-equipment` & `equipment/edit` → `<AuthGuard role="Sousakuten">`; the equipment action group, the `備品追加` nav link, the return button, and the deduction delete button → `<Internal role="Sousakuten">`.
- **Deduction scoping:** a non-admin sees only their own class — no add control, no class filter, no all-class ranking; the `class` query param is ignored and the query is pinned to their class; `/history?id=N` calls `forbidden()` for another class's record. Admins keep the full UI.

## Verification

`tsc --noEmit`, `eslint`, `prettier --check`, and `next build` all pass. Based on `main` (post-#122).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Access Control**
  * Equipment management features (add, edit, return) now require Sousakuten role authorization.
  * Non-admin users can only access deductions from their own class.
  * Equipment addition option in navigation menu is now role-restricted.
  * Deduction deletion operations now require authorization.

* **Security**
  * Authorization checks enforced for borrowing and deduction operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->