### PR TITLE
ci: auth to Forgejo container registry with a PAT

### DIFF
--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -77,9 +77,12 @@ jobs:
       - name: Log in to the container registry
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
         with:
+          # GitHub: GHCR with the built-in token. Forgejo: its own registry needs
+          # a PAT (the auto Actions token can't push packages), supplied via the
+          # FORGEJO_REGISTRY_USER / FORGEJO_REGISTRY_TOKEN Actions secrets.
           registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          username: ${{ env.REGISTRY == 'ghcr.io' && github.actor || secrets.FORGEJO_REGISTRY_USER }}
+          password: ${{ env.REGISTRY == 'ghcr.io' && secrets.GITHUB_TOKEN || secrets.FORGEJO_REGISTRY_TOKEN }}
 
       - name: Extract image metadata
         id: meta

--- a/.github/workflows/preview-image.yml
+++ b/.github/workflows/preview-image.yml
@@ -30,13 +30,18 @@ jobs:
 
     steps:
       - name: Resolve registry + image name
+        env:
+          FORGEJO_REGISTRY: ${{ vars.FORGEJO_REGISTRY }}
         run: |
-          host="${GITHUB_SERVER_URL#http://}"; host="${host#https://}"
+          host="${GITHUB_SERVER_URL#http://}"; host="${host#https://}"; host="${host%%/*}"
           if [ "$host" = "github.com" ]; then
             registry="ghcr.io"
           else
-            # Forgejo's built-in container registry shares the instance host.
-            registry="$host"
+            # On Forgejo, GITHUB_SERVER_URL is the runner's INTERNAL connection URL
+            # (forgejo:3000, plain HTTP), which docker can't use as a registry.
+            # Push to Forgejo's PUBLIC registry host over HTTPS (via nginx) instead.
+            # Override with the FORGEJO_REGISTRY repo/org variable if the host differs.
+            registry="${FORGEJO_REGISTRY:-git.kss-it.com}"
           fi
           image="${registry}/${GITHUB_REPOSITORY}/preview"
           echo "REGISTRY=${registry}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## What
Make the QEMU `preview-image.yml` able to push to **Forgejo's** container registry by authenticating with a PAT — Forgejo's automatic Actions token can't push packages.

## How
Host-aware credentials in the `docker/login` step:
- **GitHub** → GHCR with `secrets.GITHUB_TOKEN` (unchanged).
- **Forgejo** → its registry with `secrets.FORGEJO_REGISTRY_USER` + `secrets.FORGEJO_REGISTRY_TOKEN` (a PAT with `write:package`).

Requires those two Actions secrets to be set on Forgejo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container registry deployment configuration to support multiple registry hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->