### PR TITLE
Improve UI

### DIFF
--- a/components/ClassDeduction/ClassDeduction.module.css
+++ b/components/ClassDeduction/ClassDeduction.module.css
@@ -1,24 +1,30 @@
 .deduction {
   display: grid;
-  margin-left: 10px;
   grid-template-rows: 1fr;
   grid-template-columns: 0.5fr 0.5fr 1fr 1fr 5fr;
   padding: 10px 0;
   justify-items: center;
   margin: 7px 0px;
   background-color: white;
-
-  border: solid #e0e0e0 1px;
-  border-radius: 20px;
-
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.08);
   transition: all 0.3s ease;
 }
 
 .deduction:hover {
-  border-color: #007bff;
-  box-shadow: 0 6px 20px rgba(0, 123, 255, 0.15);
   transform: translateY(-1px);
+}
+
+.deductionContainer {
+  margin-left: 10px;
+  display: block;
+  background-color: white;
+  margin: 7px 0px;
+  border: solid #e0e0e0 1px;
+  border-radius: 10px;
+}
+
+:global(.dark) .deductionContainer {
+  background-color: #1a1a1a;
+  border-color: #333;
 }
 
 .deductionsample {
@@ -28,11 +34,6 @@
   grid-template-columns: 0.5fr 0.5fr 1fr 1fr 5fr;
 
   justify-items: center;
-}
-
-:global(.dark) .deduction {
-  background-color: #1a1a1a;
-  border-color: #333;
 }
 
 .deductionsample h2 {

--- a/components/ClassDeduction/ClassDeduction.module.css
+++ b/components/ClassDeduction/ClassDeduction.module.css
@@ -2,15 +2,18 @@
   display: grid;
   grid-template-rows: 1fr;
   grid-template-columns: 0.5fr 0.5fr 1fr 1fr 5fr;
-  padding: 10px 0;
   justify-items: center;
-  margin: 7px 0px;
-  background-color: white;
-  transition: all 0.3s ease;
+  padding: 13px 0;
+  transition: all 0.45s ease;
+  border-radius: 13px;
 }
 
 .deduction:hover {
-  transform: translateY(-1px);
+  background-color: #f5f5f5;
+}
+
+:global(.dark) .deduction:hover {
+  background-color: #2a2a2a;
 }
 
 .deductionContainer {
@@ -19,7 +22,7 @@
   background-color: white;
   margin: 7px 0px;
   border: solid #e0e0e0 1px;
-  border-radius: 10px;
+  border-radius: 13px;
 }
 
 :global(.dark) .deductionContainer {
@@ -45,7 +48,18 @@
 }
 
 .line {
+  margin-top: 10px;
   margin-bottom: 20px;
+}
+
+.sectionline {
+  margin: 0 10px;
+  border: none;
+  border-top: #dddddd 1px solid;
+}
+
+:global(.dark) .sectionline {
+  border-top: #333 1px solid;
 }
 
 .emptyState {
@@ -90,11 +104,10 @@
 
 @media (max-width: 768px) {
   .deduction {
-    padding: 5px;
-    padding-top: 10px;
     grid-template-rows: 20px 1fr;
-    padding-bottom: 2px;
     grid-template-columns: 1fr 2fr 2fr 2fr;
+    margin: 5px 0;
+    margin-bottom: 2px;
   }
   .content {
     padding: 15px;

--- a/components/ClassDeduction/index.tsx
+++ b/components/ClassDeduction/index.tsx
@@ -85,26 +85,29 @@ export async function DeductionCellsByClasses({
           <hr className={styles.line} />
           <div className={styles.deductionContainer}>
             {sortedDeductions.map((deduction, index) => (
-              <Link
-                href={`/history?id=${deduction.id}`}
-                key={deduction.id}
-                className={styles.linkArea}
-              >
-                <div className={styles.deduction}>
-                  <h3>{deduction.className}</h3>
-                  <p>ID: {deduction.id}</p>
-                  <p>
-                    {deduction.occurredAt.toLocaleDateString("ja-JP", {
-                      timeZone: "Asia/Tokyo",
-                    })}
-                  </p>
-                  <p>{deduction.points}</p>
-                  <p className={styles.content}>{deduction.content}</p>
-                </div>
-                {index !== deductions.length - 1 && (
+            {sortedDeductions.map((deduction, index) => (
+              <div key={deduction.id}>
+                <Link
+                  href={`/history?id=${deduction.id}`}
+                  className={styles.linkArea}
+                >
+                  <div className={styles.deduction}>
+                    <h3>{deduction.className}</h3>
+                    <p>ID: {deduction.id}</p>
+                    <p>
+                      {deduction.occurredAt.toLocaleDateString("ja-JP", {
+                        timeZone: "Asia/Tokyo",
+                      })}
+                    </p>
+                    <p>{deduction.points}</p>
+                    <p className={styles.content}>{deduction.content}</p>
+                  </div>
+                </Link>
+                {index !== sortedDeductions.length - 1 && (
                   <hr className={styles.sectionline} />
                 )}
-              </Link>
+              </div>
+            ))}
             ))}
           </div>
         </div>

--- a/components/ClassDeduction/index.tsx
+++ b/components/ClassDeduction/index.tsx
@@ -107,7 +107,6 @@ export async function DeductionCellsByClasses({
                 )}
               </div>
             ))}
-            ))}
           </div>
         </div>
       )}

--- a/components/ClassDeduction/index.tsx
+++ b/components/ClassDeduction/index.tsx
@@ -83,25 +83,27 @@ export async function DeductionCellsByClasses({
             <h2 className={styles.contentHeader}>内容</h2>
           </div>
           <hr className={styles.line} />
-          {sortedDeductions.map((deduction) => (
-            <Link
-              href={`/history?id=${deduction.id}`}
-              key={deduction.id}
-              className={styles.linkArea}
-            >
-              <div className={styles.deduction}>
-                <h3>{deduction.className}</h3>
-                <p>ID: {deduction.id}</p>
-                <p>
-                  {deduction.occurredAt.toLocaleDateString("ja-JP", {
-                    timeZone: "Asia/Tokyo",
-                  })}
-                </p>
-                <p>{deduction.points}</p>
-                <p className={styles.content}>{deduction.content}</p>
-              </div>
-            </Link>
-          ))}
+          <div className={styles.deductionContainer}>
+            {sortedDeductions.map((deduction) => (
+              <Link
+                href={`/history?id=${deduction.id}`}
+                key={deduction.id}
+                className={styles.linkArea}
+              >
+                <div className={styles.deduction}>
+                  <h3>{deduction.className}</h3>
+                  <p>ID: {deduction.id}</p>
+                  <p>
+                    {deduction.occurredAt.toLocaleDateString("ja-JP", {
+                      timeZone: "Asia/Tokyo",
+                    })}
+                  </p>
+                  <p>{deduction.points}</p>
+                  <p className={styles.content}>{deduction.content}</p>
+                </div>
+              </Link>
+            ))}
+          </div>
         </div>
       )}
     </div>

--- a/components/ClassDeduction/index.tsx
+++ b/components/ClassDeduction/index.tsx
@@ -84,7 +84,7 @@ export async function DeductionCellsByClasses({
           </div>
           <hr className={styles.line} />
           <div className={styles.deductionContainer}>
-            {sortedDeductions.map((deduction) => (
+            {sortedDeductions.map((deduction, index) => (
               <Link
                 href={`/history?id=${deduction.id}`}
                 key={deduction.id}
@@ -101,6 +101,9 @@ export async function DeductionCellsByClasses({
                   <p>{deduction.points}</p>
                   <p className={styles.content}>{deduction.content}</p>
                 </div>
+                {index !== deductions.length - 1 && (
+                  <hr className={styles.sectionline} />
+                )}
               </Link>
             ))}
           </div>

--- a/components/ClassDeduction/index.tsx
+++ b/components/ClassDeduction/index.tsx
@@ -85,7 +85,6 @@ export async function DeductionCellsByClasses({
           <hr className={styles.line} />
           <div className={styles.deductionContainer}>
             {sortedDeductions.map((deduction, index) => (
-            {sortedDeductions.map((deduction, index) => (
               <div key={deduction.id}>
                 <Link
                   href={`/history?id=${deduction.id}`}

--- a/components/DeductionPopup/DeductionPopup.module.css
+++ b/components/DeductionPopup/DeductionPopup.module.css
@@ -94,7 +94,7 @@
 }
 
 :global(.dark) .button {
-  background-color: #1a1a1a;
+  background-color: #543232;
   color: white;
 }
 
@@ -103,7 +103,7 @@
 }
 
 :global(.dark) .button:hover {
-  background-color: #252525;
+  background-color: #5a1f1f;
 }
 
 .closeButton {

--- a/content/changelog/0134-changelog.json
+++ b/content/changelog/0134-changelog.json
@@ -1,0 +1,5 @@
+{
+  "title": "UIの軽微な修正",
+  "description": "減点システムの表示UIの軽微な修正が行われました",
+  "credits": ["@Shirym-min"]
+}


### PR DESCRIPTION
減点部分のUIの表示方法を複数枚のカード形式ではなく、リスト形式に変更する軽微な調整を行いました。また、ダークモード時の減点ボタンを赤くしました。

<img width="1697" height="928" alt="スクリーンショット 2026-06-26 19 30 39" src="https://github.com/user-attachments/assets/afb7d276-5e18-4337-95f3-51163125b9e2" />

（なお、ここでは.env.localのバイバスシステムを使ったプレビューを行っていますが、このPRにはそのシステムは含まれていません。）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Deduction history now uses a more grouped layout with clear entry separation via horizontal dividers.
* **Bug Fixes**
  * Improved responsive spacing and grid behavior for deduction cards on smaller screens.
* **Style**
  * Refined deduction card visuals, including updated hover behavior and revised dark-mode styling, plus improved container presentation.
  * Adjusted dark-mode button background colors in the deduction popup for better consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->