### PR TITLE
Local login bypass system

### DIFF
--- a/lib/session.ts
+++ b/lib/session.ts
@@ -212,6 +212,12 @@ export async function validateSessionToken(
  * request via React cache().
  */
 export const getCurrentUser = cache(async (): Promise<SessionUser | null> => {
+  if (process.env.LOCAL_DEV_USER && process.env.NODE_ENV === "development") {
+    return {
+      username: process.env.LOCAL_DEV_USER,
+      roles: (process.env.LOCAL_DEV_ROLES?.split(",") ?? []) as string[],
+    };
+  }
   const cookieStore = await cookies();
   const token = cookieStore.get(SESSION_COOKIE_NAME)?.value;
   if (!token) return null;

--- a/lib/session.ts
+++ b/lib/session.ts
@@ -215,7 +215,8 @@ export const getCurrentUser = cache(async (): Promise<SessionUser | null> => {
   if (process.env.LOCAL_DEV_USER && process.env.NODE_ENV === "development") {
     return {
       username: process.env.LOCAL_DEV_USER,
-      roles: (process.env.LOCAL_DEV_ROLES?.split(",") ?? []) as string[],
+      roles: (process.env.LOCAL_DEV_ROLES?.split(/[,\s]+/).filter(Boolean) ??
+        []) as string[],
     };
   }
   const cookieStore = await cookies();


### PR DESCRIPTION
close #139
ローカルでDBなしでログインすることができるようになります。
使い方としては、.env.localを用意し、
``` env
LOCAL_DEV_USER=3C22
LOCAL_DEV_ROLES=Sousakuten
```
このように入力し、
``` bash
npm run dev
```
で開発用サーバーを立ち上げることでログインせずに委員用の画面をテストすることができます。
LOCAL_DEV_ROLESに別の言葉を入れれば委員以外の人が見る画面にもできます。

なお、developmentの時しか有効にならないようになっているため本番環境では動きません。（一応環境変数には入れないようにしてください）